### PR TITLE
Switch from fastify to express

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/platform-fastify": "^10.3.1",
     "@nestjs/typeorm": "^10.0.1",
     "axios": "^1.6.7",
     "bcrypt": "^5.1.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,17 @@
 import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
-import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify'
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { NestExpressApplication } from '@nestjs/platform-express'
 
 async function bootstrap () {
   const httpsOptions = {
     key: readFileSync(join(__dirname, '../secrets/private-key.pem'), 'utf8'),
     cert: readFileSync(join(__dirname, '../secrets/public-certificate.pem'), 'utf8')
   }
-  const app = await NestFactory.create<NestFastifyApplication>(
-    AppModule,
-    new FastifyAdapter({ logger: true, https: httpsOptions })
-  )
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, { httpsOptions })
+
   await app.listen(3000, '0.0.0.0')
-  console.log(`Application with TypeORM and Fastify is running on: ${await app.getUrl()}`)
+  console.log(`Application with TypeORM and Express is running on: ${await app.getUrl()}`)
 }
 bootstrap()


### PR DESCRIPTION
I originally tried to use fastify as the http module because it's (on average) 27% faster, but had too much trouble figuring out how to register fastify secure sessions with the FastifyAdapter. Most of my executions operate in under a second and the majority of the time is spent waiting on resy to return when I call them. Likely only 100ms of (say) the 900ms is due to express inefficiencies.

The headache to shave 27ms off my runtime is not worth it, so I'm moving back to express